### PR TITLE
Add BetterCodeHub config

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,4 @@
+component_depth: 2
+
+languages:
+- ruby


### PR DESCRIPTION
The config file is needed to tell BCH to not judge us for having everything in the `lib` folder, since this is how it is supposed to be done. This should bring BCH score to 10/10.