### PR TITLE
Have PRETTY_TRACE=full ignore filters as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ in your ruby script, and errors will become clearer and more readable.
 
 ---
 
+
 Install
 --------------------------------------------------
 
@@ -32,6 +33,7 @@ gem 'pretty_trace', require: 'pretty_trace/enable'
 # Or, install, enable and enable trimming
 gem 'pretty_trace', require: 'pretty_trace/enable-trim'
 ```
+
 
 Example
 --------------------------------------------------
@@ -115,10 +117,20 @@ to see the full trace paths), you can set the environment variable
 $ PRETTY_TRACE=off ruby myscript.rb
 ```
 
-If you wish to temporarily disable trimming, you can set the environment 
-variable `PRETTY_TRACE=full` before running your script:
+If you wish to temporarily disable trimming and filtering, you can set the
+environment variable `PRETTY_TRACE=full` before running your script:
 
 ```
 $ PRETTY_TRACE=full ruby myscript.rb
 ```
 
+
+Contributing / Support
+--------------------------------------------------
+
+If you experience any issue, have a question or a suggestion, or if you wish
+to contribute, feel free to [open an issue][issues].
+
+---
+
+[issues]: https://github.com/DannyBen/pretty_trace/issues

--- a/lib/pretty_trace/handler.rb
+++ b/lib/pretty_trace/handler.rb
@@ -34,7 +34,7 @@ module PrettyTrace
       @options = new_options
     end
 
-    private
+  private
 
     def ignored
       # :nocov:

--- a/lib/pretty_trace/structured_backtrace.rb
+++ b/lib/pretty_trace/structured_backtrace.rb
@@ -13,8 +13,10 @@ module PrettyTrace
 
       result = backtrace.dup
 
-      filter.each do |expression|
-        result.reject! { |trace| trace =~ expression }
+      unless ENV['PRETTY_TRACE'] == 'full'
+        filter.each do |expression|
+          result.reject! { |trace| trace =~ expression }
+        end
       end
 
       result.map! { |line| BacktraceItem.new line }
@@ -35,7 +37,7 @@ module PrettyTrace
       formatted_backtrace.join "\n"
     end
 
-    private
+  private
 
     def should_trim?(backtrace)
       options[:trim] and ENV['PRETTY_TRACE'] != 'full' and backtrace.size > 3


### PR DESCRIPTION
Setting `PRETTY_TRACE=full` will now also display user-filtered lines.