### PR TITLE
Fix display when backtrace is empty

### DIFF
--- a/lib/pretty_trace.rb
+++ b/lib/pretty_trace.rb
@@ -4,3 +4,5 @@ require 'pretty_trace/backtrace_item'
 require 'pretty_trace/handler'
 require 'pretty_trace/structured_backtrace'
 require 'pretty_trace/module_methods'
+
+require 'byebug' if ENV['BYEBUG']

--- a/lib/pretty_trace/handler.rb
+++ b/lib/pretty_trace/handler.rb
@@ -45,7 +45,9 @@ module PrettyTrace
     def show_errors(exception)
       # :nocov:
       backtrace = StructuredBacktrace.new exception.backtrace, options
-      puts "\n#{backtrace}"
+
+      puts "\n#{backtrace}" unless backtrace.empty?
+
       message = exception.message
       if message.empty?
         puts "\n%{blue}#{exception.class}%{reset}\n" % colors

--- a/lib/pretty_trace/structured_backtrace.rb
+++ b/lib/pretty_trace/structured_backtrace.rb
@@ -24,7 +24,9 @@ module PrettyTrace
       result.reverse!
       result.uniq!(&:path) if should_trim? result
 
-      result.push first_line unless first_line.original_line == result[-1].original_line
+      if first_line and first_line.original_line != result[-1].original_line
+        result.push first_line
+      end
 
       result
     end
@@ -35,6 +37,10 @@ module PrettyTrace
 
     def to_s
       formatted_backtrace.join "\n"
+    end
+
+    def empty?
+      formatted_backtrace.empty?
     end
 
   private

--- a/spec/fixtures/filtered_hell_raiser.rb
+++ b/spec/fixtures/filtered_hell_raiser.rb
@@ -1,0 +1,5 @@
+require 'pretty_trace/enable'
+
+PrettyTrace.filter /fixtures/
+
+raise 'hell'

--- a/spec/pretty_trace/handler_spec.rb
+++ b/spec/pretty_trace/handler_spec.rb
@@ -10,6 +10,14 @@ describe Handler do
     it "catches all exceptions on exit" do
       expect(`#{subject}`).to match(/\nline.*\[32m.*\[0m.*\[36mfixtures.*\[35mhell_raiser/)
     end
+
+    context "when the backtrace is empty" do
+      subject { "bundle exec ruby spec/fixtures/filtered_hell_raiser.rb" }
+
+      it "only shows the error" do
+        expect(`#{subject}`).to eq "\n\e[34mRuntimeError\n\e[31mhell\e[0m\n"
+      end
+    end
   end
 
   context "when disabled" do

--- a/spec/pretty_trace/structured_backtrace_spec.rb
+++ b/spec/pretty_trace/structured_backtrace_spec.rb
@@ -32,7 +32,15 @@ describe StructuredBacktrace do
         expect(subject.structure.count).to be 3
         expect(subject.structure.first.path).to eq 'file'
       end
-    end    
+    end
+
+    context "when backtrace is empty" do
+      subject { described_class.new short_backtrace, filter: [/lib/, /file/] }
+
+      it "returns an empty array" do
+        expect(subject.structure).to eq []
+      end
+    end
 
     context "with trim" do
       subject { described_class.new backtrace, trim: true }
@@ -64,6 +72,22 @@ describe StructuredBacktrace do
         it "temporarily disables trimming" do
           expect(subject.structure.count).to be 7
         end
+      end
+    end
+  end
+
+  describe '#empty?' do
+    context "when there is a backtrace" do
+      it "returns false" do
+        expect(subject.empty?).to be false
+      end
+    end
+
+    context "when there is no backtrace" do
+      subject { described_class.new short_backtrace, filter: [/lib/, /file/] }
+
+      it "returns true" do
+        expect(subject.empty?).to be true
       end
     end
   end


### PR DESCRIPTION
When backtrace is completely empty - for example, due to user filters - pretty_trace currently fails.

This PR fixes it, so empty backtrace causes just the usual pretty display of the error, without the backtrace.