### PR TITLE
Add optional debug tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Pretty Trace - Pretty Errors and Backtrace
-==================================================
+# Pretty Trace - Pretty Errors and Backtrace
 
 [![Gem Version](https://badge.fury.io/rb/pretty_trace.svg)](https://badge.fury.io/rb/pretty_trace)
 [![Build Status](https://github.com/DannyBen/pretty_trace/workflows/Test/badge.svg)](https://github.com/DannyBen/pretty_trace/actions?query=workflow%3ATest)
@@ -13,10 +12,9 @@ in your ruby script, and errors will become clearer and more readable.
 ---
 
 
-Install
---------------------------------------------------
+## Install
 
-```
+```shell
 $ gem install pretty_trace
 ```
 
@@ -34,8 +32,7 @@ gem 'pretty_trace', require: 'pretty_trace/enable-trim'
 ```
 
 
-Example
---------------------------------------------------
+## Example
 
 ### Create this ruby file:
 
@@ -51,8 +48,7 @@ FileUtils.rm 'no_such_file'
 ![screenshot](/screenshot.gif)
 
 
-Usage
---------------------------------------------------
+## Usage
 
 The easiest way to use Pretty Trace is to require its activation script in
 your script:
@@ -93,8 +89,9 @@ PrettyTrace.no_trim
 ```
 
 
-Configuration
---------------------------------------------------
+## Configuration
+
+### Filtering specific paths
 
 To filter out lines in the backtrace, use `PrettyTrace.filter`. This method
 accepts a single regular expression, or an array of regular expressions.
@@ -112,20 +109,28 @@ If you wish to temporarily disable Pretty Trace (for example, when you need
 to see the full trace paths), you can set the environment variable 
 `PRETTY_TRACE=off` before running your script:
 
-```
+```shell
 $ PRETTY_TRACE=off ruby myscript.rb
 ```
 
 If you wish to temporarily disable trimming and filtering, you can set the
 environment variable `PRETTY_TRACE=full` before running your script:
 
-```
+```shell
 $ PRETTY_TRACE=full ruby myscript.rb
 ```
 
+### Showing a debug tip
 
-Contributing / Support
---------------------------------------------------
+If you wish to see a debug tip, reminding you to set `PRETTY_TRACE` to `full` or `off` when an error occurs, use `PrettyTrace.debug_tip`:
+
+```ruby
+require 'pretty_trace/enable'
+PrettyTrace.debug_tip     # enable debug tip
+PrettyTrace.no_debug_tip  # disable debug tip
+```
+
+## Contributing / Support
 
 If you experience any issue, have a question or a suggestion, or if you wish
 to contribute, feel free to [open an issue][issues].

--- a/lib/pretty_trace/handler.rb
+++ b/lib/pretty_trace/handler.rb
@@ -54,6 +54,11 @@ module PrettyTrace
       else
         puts "\n%{blue}#{exception.class}\n%{red}#{message}%{reset}\n" % colors
       end
+
+      if options[:debug_tip] and ENV['PRETTY_TRACE'] != 'full'
+        puts "\nTIP: Run with %{cyan}PRETTY_TRACE=full%{reset} (or %{cyan}off%{reset}) for debug information" % colors
+      end
+
       $stdout.flush
       # :nocov:
     end

--- a/lib/pretty_trace/module_methods.rb
+++ b/lib/pretty_trace/module_methods.rb
@@ -15,6 +15,14 @@ module PrettyTrace
     end
   end
 
+  def self.debug_tip
+    Handler.instance.options[:debug_tip] = true
+  end
+
+  def self.no_debug_tip
+    Handler.instance.options[:debug_tip] = false
+  end
+
   def self.trim
     Handler.instance.options[:trim] = true
   end

--- a/spec/fixtures/tipper.rb
+++ b/spec/fixtures/tipper.rb
@@ -1,0 +1,3 @@
+require 'pretty_trace/enable'
+PrettyTrace.debug_tip
+raise 'hell'

--- a/spec/pretty_trace/handler_spec.rb
+++ b/spec/pretty_trace/handler_spec.rb
@@ -18,6 +18,14 @@ describe Handler do
         expect(`#{subject}`).to eq "\n\e[34mRuntimeError\n\e[31mhell\e[0m\n"
       end
     end
+
+    context "when debug_tip is on" do
+      subject { "bundle exec ruby spec/fixtures/tipper.rb" }
+      
+      it "shows a friendly debug tip" do
+        expect(`#{subject}`).to match %r{Run with .*PRETTY_TRACE=full.*for debug information}
+      end
+    end
   end
 
   context "when disabled" do

--- a/spec/pretty_trace/module_methods_spec.rb
+++ b/spec/pretty_trace/module_methods_spec.rb
@@ -40,6 +40,24 @@ describe PrettyTrace do
     end
   end
 
+  describe '::debug_tip' do
+    it "enables debug tip" do
+      subject.debug_tip
+      expect(handler.options[:debug_tip]).to be true
+    end
+  end
+
+  describe '::no_debug_tip' do
+    before do 
+      handler.options = { debug_tip: true }
+    end
+
+    it "disabled debug tip" do
+      subject.no_debug_tip
+      expect(handler.options[:debug_tip]).to be false
+    end
+  end
+
   describe '::filter' do
     before do
       handler.options = { filter: [/default/] }


### PR DESCRIPTION
Allow setting `PrettyTrace.debug_tip` so that errors also remind the user that they can always see the backtrace by setting `PRETTY_TRACE` to `full` or `off`.

This is provided so when using this library in something that is executed by a non-developer user, which are not familiar with how it works, they can help themselves to some backtrace.
