### PR TITLE
Refactor singletons

### DIFF
--- a/lib/pretty_trace/handler.rb
+++ b/lib/pretty_trace/handler.rb
@@ -1,70 +1,69 @@
-require 'singleton'
-
 module PrettyTrace
   class Handler
-    include Singleton
-    include Colors
+    class << self
+      include Colors
 
-    def enable
-      @enabled = true
-      # :nocov: - this is actually covered through an external process
-      at_exit do
-        if @enabled and $! and !ignored.include? $!.class
-          show_errors $!
-          $stderr.reopen IO::NULL
-          $stdout.reopen IO::NULL
+      def enable
+        @enabled = true
+        # :nocov: - this is actually covered through an external process
+        at_exit do
+          if @enabled and $! and !ignored.include? $!.class
+            show_errors $!
+            $stderr.reopen IO::NULL
+            $stdout.reopen IO::NULL
+          end
         end
-      end
-      # :nocov:
-    end
-
-    def disable
-      @enabled = false
-    end
-
-    def enabled?
-      @enabled
-    end
-
-    def options
-      @options ||= default_options
-    end
-
-    def options=(new_options)
-      @options = new_options
-    end
-
-  private
-
-    def ignored
-      # :nocov:
-      [ SystemExit ]
-      # :nocov:
-    end
-
-    def show_errors(exception)
-      # :nocov:
-      backtrace = StructuredBacktrace.new exception.backtrace, options
-
-      puts "\n#{backtrace}" unless backtrace.empty?
-
-      message = exception.message
-      if message.empty?
-        puts "\n%{blue}#{exception.class}%{reset}\n" % colors
-      else
-        puts "\n%{blue}#{exception.class}\n%{red}#{message}%{reset}\n" % colors
+        # :nocov:
       end
 
-      if options[:debug_tip] and ENV['PRETTY_TRACE'] != 'full'
-        puts "\nTIP: Run with %{cyan}PRETTY_TRACE=full%{reset} (or %{cyan}off%{reset}) for debug information" % colors
+      def disable
+        @enabled = false
       end
 
-      $stdout.flush
-      # :nocov:
-    end
+      def enabled?
+        @enabled
+      end
 
-    def default_options
-      { filter: [] }
+      def options
+        @options ||= default_options
+      end
+
+      def options=(new_options)
+        @options = new_options
+      end
+
+    private
+
+      def ignored
+        # :nocov:
+        [ SystemExit ]
+        # :nocov:
+      end
+
+      def show_errors(exception)
+        # :nocov:
+        backtrace = StructuredBacktrace.new exception.backtrace, options
+
+        puts "\n#{backtrace}" unless backtrace.empty?
+
+        message = exception.message
+        if message.empty?
+          puts "\n%{blue}#{exception.class}%{reset}\n" % colors
+        else
+          puts "\n%{blue}#{exception.class}\n%{red}#{message}%{reset}\n" % colors
+        end
+
+        if options[:debug_tip] and ENV['PRETTY_TRACE'] != 'full'
+          puts "\nTIP: Run with %{cyan}PRETTY_TRACE=full%{reset} (or %{cyan}off%{reset}) for debug information" % colors
+        end
+
+        $stdout.flush
+        # :nocov:
+      end
+
+      def default_options
+        { filter: [] }
+      end
     end
   end
-end;
+end

--- a/lib/pretty_trace/module_methods.rb
+++ b/lib/pretty_trace/module_methods.rb
@@ -1,33 +1,35 @@
 module PrettyTrace
-  def self.enable
-    Handler.instance.enable unless ENV['PRETTY_TRACE'] == 'off'
-  end
-
-  def self.disable
-    Handler.instance.disable
-  end
-
-  def self.filter(filter)
-    if filter.is_a? Array
-      Handler.instance.options[:filter] += filter
-    else
-      Handler.instance.options[:filter] << filter
+  class << self
+    def enable
+      Handler.enable unless ENV['PRETTY_TRACE'] == 'off'
     end
-  end
 
-  def self.debug_tip
-    Handler.instance.options[:debug_tip] = true
-  end
+    def disable
+      Handler.disable
+    end
 
-  def self.no_debug_tip
-    Handler.instance.options[:debug_tip] = false
-  end
+    def filter(filter)
+      if filter.is_a? Array
+        Handler.options[:filter] += filter
+      else
+        Handler.options[:filter] << filter
+      end
+    end
 
-  def self.trim
-    Handler.instance.options[:trim] = true
-  end
+    def debug_tip
+      Handler.options[:debug_tip] = true
+    end
 
-  def self.no_trim
-    Handler.instance.options[:trim] = false
+    def no_debug_tip
+      Handler.options[:debug_tip] = false
+    end
+
+    def trim
+      Handler.options[:trim] = true
+    end
+
+    def no_trim
+      Handler.options[:trim] = false
+    end
   end
 end

--- a/spec/pretty_trace/handler_spec.rb
+++ b/spec/pretty_trace/handler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Handler do
-  subject { described_class.instance }
+  subject { described_class }
 
   context "when enabled" do
     # We must run this in an external ruby file because... REASONS!

--- a/spec/pretty_trace/module_methods_spec.rb
+++ b/spec/pretty_trace/module_methods_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
 describe PrettyTrace do
-  let(:handler) { Handler.instance }
+  let(:handler) { Handler }
   subject { described_class }
   
   describe '::enable' do
-    it "enables the handler instance" do
+    it "enables the handler" do
       expect(handler).to receive :enable
       subject.enable
     end
   end
 
   describe '::disable' do
-    it "disables the handler instance" do
+    it "disables the handler" do
       expect(handler).to receive :disable
       subject.disable
     end
@@ -81,5 +81,4 @@ describe PrettyTrace do
       end
     end
   end
-
 end


### PR DESCRIPTION
Remove the use of the `Singleton` module, and the `self.*` notation in favor of `class << self`.