### PR TITLE
Add ability to reverse output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /doc
 /Gemfile.lock
 /gems
+/spec/coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ inherit_gem:
     - rspec.yml
 
 AllCops:
+  SuggestExtensions: false
   TargetRubyVersion: 3.0
   Exclude:
     - 'dev/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'debug'
 gem 'rspec'
+gem 'rspec_approvals'
 gem 'runfile'
 gem 'runfile-tasks'
 gem 'simplecov'

--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ PrettyTrace.disable
 
 PrettyTrace.enable
 PrettyTrace.trim
-# Exceptions here will be formatted and trimmed
+PrettyTrace.reverse
+# Exceptions here will be formatted, trimmed and in reverse order
 
 PrettyTrace.no_trim
-# Exceptions here will not be trimmed
+PrettyTrace.no_reverse
+# Exceptions here will not be trimmed or reversed
 ```
 
 

--- a/lib/pretty_trace/module_methods.rb
+++ b/lib/pretty_trace/module_methods.rb
@@ -31,5 +31,13 @@ module PrettyTrace
     def no_trim
       Handler.options[:trim] = false
     end
+
+    def reverse
+      Handler.options[:reverse] = true
+    end
+
+    def no_reverse
+      Handler.options[:reverse] = false
+    end
   end
 end

--- a/lib/pretty_trace/structured_backtrace.rb
+++ b/lib/pretty_trace/structured_backtrace.rb
@@ -9,11 +9,13 @@ module PrettyTrace
 
     def structure
       result = backtrace_list.map { |line| BacktraceItem.new line }
-      if should_trim? result
+      result = if should_trim? result
         result.group_by(&:path).flat_map { |_, items| [items.first, items.last].uniq }
       else
         result
       end
+
+      should_reverse? ? result.reverse : result
     end
 
     def formatted_backtrace
@@ -49,6 +51,10 @@ module PrettyTrace
 
     def should_trim?(backtrace)
       options[:trim] and ENV['PRETTY_TRACE'] != 'full' and backtrace.size > 3
+    end
+
+    def should_reverse?
+      options[:reverse]
     end
   end
 end

--- a/spec/approvals/structured_backtrace/formatted_backtrace
+++ b/spec/approvals/structured_backtrace/formatted_backtrace
@@ -1,0 +1,7 @@
+line [32m1   [0m in [36m[35mfile[0m > [34mone[0m
+line [32m2   [0m in [36m[35mfile[0m > [34mtwo[0m
+line [32m3   [0m in [36m[35mfile[0m > [34mthree[0m
+line [32m1   [0m in [36m[35mlib[0m > [34mfour[0m
+line [32m2   [0m in [36m[35mlib[0m > [34mfive[0m
+line [32m3   [0m in [36m[35mlib[0m > [34msix[0m
+line [32m4   [0m in [36m[35mlib[0m > [34mseven[0m

--- a/spec/approvals/structured_backtrace/to_s
+++ b/spec/approvals/structured_backtrace/to_s
@@ -1,0 +1,7 @@
+line [32m1   [0m in [36m[35mfile[0m > [34mone[0m
+line [32m2   [0m in [36m[35mfile[0m > [34mtwo[0m
+line [32m3   [0m in [36m[35mfile[0m > [34mthree[0m
+line [32m1   [0m in [36m[35mlib[0m > [34mfour[0m
+line [32m2   [0m in [36m[35mlib[0m > [34mfive[0m
+line [32m3   [0m in [36m[35mlib[0m > [34msix[0m
+line [32m4   [0m in [36m[35mlib[0m > [34mseven[0m

--- a/spec/pretty_trace/pretty_trace_spec.rb
+++ b/spec/pretty_trace/pretty_trace_spec.rb
@@ -41,6 +41,29 @@ describe PrettyTrace do
     end
   end
 
+  describe '::reverse' do
+    before do
+      handler.options = {}
+    end
+
+    it 'enables reverse order' do
+      subject.reverse
+      expect(handler.options[:reverse]).to be true
+    end
+  end
+
+  describe '::no_reverse' do
+    before do
+      handler.options = { reverse: true }
+    end
+
+    it 'disables reverse order' do
+      subject.no_reverse
+      expect(handler.options[:reverse]).to be false
+    end
+  end
+
+
   describe '::debug_tip' do
     it 'enables debug tip' do
       subject.debug_tip

--- a/spec/pretty_trace/structured_backtrace_spec.rb
+++ b/spec/pretty_trace/structured_backtrace_spec.rb
@@ -5,20 +5,20 @@ describe StructuredBacktrace do
 
   let(:backtrace) do
     [
-      "file:1:in `one'",
-      "file:2:in `two'",
-      "file:3:in `three'",
-      "lib:1:in `four'",
-      "lib:2:in `five'",
-      "lib:3:in `six'",
       "lib:4:in `seven'",
+      "lib:3:in `six'",
+      "lib:2:in `five'",
+      "lib:1:in `four'",
+      "file:3:in `three'",
+      "file:2:in `two'",
+      "file:1:in `one'",
     ]
   end
 
   let(:short_backtrace) do
     [
-      "file:1:in `method'",
       "lib:2:in `method'",
+      "file:1:in `method'",
     ]
   end
 
@@ -26,7 +26,7 @@ describe StructuredBacktrace do
     it 'returns a reversed array of BacktraceItems' do
       expect(subject.structure).to be_an Array
       expect(subject.structure.first).to be_a BacktraceItem
-      expect(subject.structure.first.method).to eq 'seven'
+      expect(subject.structure.first.method).to eq 'one'
     end
 
     context 'with filter' do
@@ -51,10 +51,10 @@ describe StructuredBacktrace do
 
       it 'keeps the first and the last line of each file' do
         expect(subject.structure.count).to be 4
-        expect(subject.structure[0].method).to eq 'seven'
-        expect(subject.structure[1].method).to eq 'four'
-        expect(subject.structure[2].method).to eq 'three'
-        expect(subject.structure[3].method).to eq 'one'
+        expect(subject.structure[0].method).to eq 'one'
+        expect(subject.structure[1].method).to eq 'three'
+        expect(subject.structure[2].method).to eq 'four'
+        expect(subject.structure[3].method).to eq 'seven'
       end
 
       context 'when backtrace is 3 locations or less' do
@@ -79,6 +79,15 @@ describe StructuredBacktrace do
         end
       end
     end
+
+    context 'with reverse' do
+      subject { described_class.new backtrace, reverse: true }
+
+      it 'shows the first file last' do
+        expect(subject.structure[0].method).to eq 'seven'
+        expect(subject.structure[6].method).to eq 'one'
+      end
+    end
   end
 
   describe '#empty?' do
@@ -100,14 +109,15 @@ describe StructuredBacktrace do
   describe '#formatted_backtrace' do
     it 'returns an array of color highlighted strings' do
       expect(subject.formatted_backtrace).to be_an Array
-      expect(subject.formatted_backtrace.first).to match(/line.*\[32m4.*\[0m.*\[36m.*\[35mlib.*\[0m.*\[34mseven.*\[0m/)
+      expect(subject.formatted_backtrace.join("\n"))
+        .to match_approval('structured_backtrace/formatted_backtrace')
     end
   end
 
   describe '#to_s' do
     it 'returns a merged formatted_backtrace' do
       expect(subject.to_s).to be_a String
-      expect(subject.to_s).to match(/line.*\[32m4.*\[0m/)
+      expect(subject.to_s).to match_approval('structured_backtrace/to_s')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 require 'simplecov'
-SimpleCov.start
+
+unless ENV['NOCOV']
+  SimpleCov.start do
+    enable_coverage :branch if ENV['BRANCH_COV']
+    coverage_dir 'spec/coverage'
+  end
+end
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
Calling `PrettyTrace.reverse` will output in reverse order (first backtrace item will appear last).