### PR TITLE
Update for Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['3.0', '3.1', '3.2', '3.3'] }
+      matrix: { ruby: ['3.0', '3.1', '3.2', '3.3', '3.4.0-preview2'] }
 
     steps:
     - name: Checkout code

--- a/lib/pretty_trace/backtrace_item.rb
+++ b/lib/pretty_trace/backtrace_item.rb
@@ -8,7 +8,7 @@ module PrettyTrace
       @original_line = original_line
       @formatted = false
 
-      return unless @original_line =~ /(.+):(-?\d+):in `(.+)'/
+      return unless @original_line =~ /(.+):(-?\d+):in [`'](.+)'/
 
       @formatted = true
       @path = $1

--- a/spec/pretty_trace/handler_spec.rb
+++ b/spec/pretty_trace/handler_spec.rb
@@ -30,7 +30,8 @@ describe Handler do
     subject { 'bundle exec ruby spec/fixtures/disabled_hell_raiser.rb' }
 
     it 'raises exceptions normally' do
-      expect(`#{subject} 2>&1`).to match_approval('handler/disabled')
+      # allow 1 letter diff, since ruby 3.4 uses 'var' instead of `var'
+      expect(`#{subject} 2>&1`).to match_approval('handler/disabled').diff(1)
     end
 
     it 'exits with a non zero code' do


### PR DESCRIPTION
Ruby 3.4 uses `'varname'` instead of `` `varname' `` in its backtrace. This PR updates the regular expression to match.